### PR TITLE
June2018 updates

### DIFF
--- a/_layouts/listing.html
+++ b/_layouts/listing.html
@@ -53,7 +53,7 @@
         <div class="features">
           <div class="menu">
             <div class="highlights">
-              <h2 class="sidebar-header"><strong>PROPERTY</strong><span class="subdued"> HIGHLIGHTS</span></h2>
+              <h2 class="sidebar-header"><strong>HIGHLIGHTS</strong></h2>
               <ul class="list">
                 {% for highlight in page.highlights %}
                   <li>{{ highlight }}</li>
@@ -126,7 +126,7 @@
                       <div>{{page.address-line-1}}</div>
                       <div>{{page.address-line-2}}</div>
                     </div>
-                    <h2 class="sidebar-header"><span class="subdued"><strong>PROPERTY</strong> HIGHLIGHTS</span></h2>
+                    <h2 class="sidebar-header"><strong>HIGHLIGHTS</strong></h2>
                     <hr class ="light-line">
                     <ul class="amenity-list">
                       {% for highlight in page.highlights %}

--- a/_layouts/listings.html
+++ b/_layouts/listings.html
@@ -117,6 +117,9 @@
                               {% if listing.lease %}
                                 <div class="listing-label lease-label">For Lease</div>
                               {% endif %}
+                              {% if listing.lease %}
+                                <div class="listing-label lease-label">For Sublease</div>
+                              {% endif %}
                               {% if listing.sale %}
                                 <div class="listing-label rent-label">For Sale</div>
                               {% endif %}

--- a/_layouts/listings.html
+++ b/_layouts/listings.html
@@ -118,7 +118,7 @@
                                 <div class="listing-label lease-label">For Lease</div>
                               {% endif %}
                               {% if listing.sublease %}
-                                <div class="listing-label lease-label">For Sublease</div>
+                                <div class="listing-label sublease-label">For Sublease</div>
                               {% endif %}
                               {% if listing.sale %}
                                 <div class="listing-label rent-label">For Sale</div>

--- a/_layouts/listings.html
+++ b/_layouts/listings.html
@@ -62,16 +62,16 @@
               </select>
               <input class="listings__filter" id="min-size" type="text" placeholder=" Min. Size" class="subdued">
               <input class="listings__filter" id="max-price" type="text" placeholder=" Price" class="subdued">
+              <select name="type" id="type-filter" class="listings__filter">
+                <option value="n/a">Any Type</option>
+                <option value="lease">Lease</option>
+                <option value="sublease">Sublease</option>
+              </select>
               <!-- Disabled filters... to enable, uncomment and alter the JS filter -->
               <!-- <select name="status" id="status-filter">
                 <option value="n/a">Any Status</option>
                 <option value="true">Available Now</option>
                 <option value="false">Not Available</option>
-              </select> -->
-              <!-- <select name="type" id="type-filter">
-                <option value="n/a">Any Type</option>
-                <option value="lease">Lease</option>
-                <option value="buy">Buy</option>
               </select> -->
               <!-- <select name="min-rooms" id="min-rooms">
                 <option value="1">Min. Rooms</option>
@@ -90,7 +90,7 @@
           <div id="properties" class="flexbox listings">
             {% assign listings = site.listings | where: "layout", "listing" | where: "hidden", "false" %}
             {% for listing in listings %}
-              <div class="listing-preview" data-location="{{listing.address-line-2}}" data-available="{{listing.available}}" data-lease="{{listing.lease}}" data-buy="{{listing.buy}}" data-rooms="{{listing.rooms}}" data-size="{{listing.sq-footage}}" data-price="{{listing.price}}">
+              <div class="listing-preview" data-location="{{listing.address-line-2}}" data-available="{{listing.available}}" data-lease="{{listing.lease}}" data-sublease="{{listing.sublease}}" data-buy="{{listing.buy}}" data-rooms="{{listing.rooms}}" data-size="{{listing.sq-footage}}" data-price="{{listing.price}}">
                 <a href={{listing.url}}>
                   {% if listing.property-preview-image %}
                     <div class="header" style="background-image:url({{listing.property-preview-image}})">
@@ -117,7 +117,7 @@
                               {% if listing.lease %}
                                 <div class="listing-label lease-label">For Lease</div>
                               {% endif %}
-                              {% if listing.lease %}
+                              {% if listing.sublease %}
                                 <div class="listing-label lease-label">For Sublease</div>
                               {% endif %}
                               {% if listing.sale %}

--- a/_layouts/newsletter.html
+++ b/_layouts/newsletter.html
@@ -116,7 +116,7 @@
             <tr>
               <td width="50px"></td>
               <td width="800px" class="padding-bottom">
-                <span class="list-header">BUILDING HIGHLIGHTS</span>
+                <span class="list-header">HIGHLIGHTS</span>
                 <ul class="newsletter-highlights">
                   {% for highlight in page.highlights %}
                   <li>{{ highlight }}</li>

--- a/_layouts/newsletter.html
+++ b/_layouts/newsletter.html
@@ -99,7 +99,7 @@
               <td width="50px"></td>
               <td width="400px" valign="top" class="bodyContent border-right">
                 <img class="amenities__icon" src="/images/newsletter/img/gs-newsletter-icon-3.png" width="45" height="45" alt="Rate" />
-                <span class="amenities__text"><span class="strong">Available:</span> {{ page.date | date: "%m/%d/%Y" }}</span>
+                <span class="amenities__text"><span class="strong">Available:</span><span id="available-date" data-date="{{ page.date }}"> {{ page.date | date: "%m/%d/%Y" }}</span></span>
               </td>
               <td width="400px" valign="top" class="bodyContent">
                 <img class="amenities__icon" src="/images/newsletter/img/gs-newsletter-icon-4.png" width="45" height="45" alt="Rate" />
@@ -168,5 +168,21 @@
         </td>
       </tr>
     </table>
+    <script>
+      (function() {
+        listingAvailable();
+      })();
+
+      function listingAvailable() {
+        var dateDiv = document.getElementById('available-date')
+        var availableDate = new Date(dateDiv.dataset.date)
+        var today = new Date()
+        var availableNow = today > availableDate
+
+        if (availableNow) {
+          dateDiv.innerHTML = " Immediately"
+        }
+      }
+    </script>
   </body>
 </html>

--- a/_layouts/newsletter.html
+++ b/_layouts/newsletter.html
@@ -36,6 +36,9 @@
                 {% if page.lease %}
                 <div class="listing-label-newsletter lease-label">FOR LEASE</div>
                 {% endif %}
+                {% if page.sublease %}
+                <div class="listing-label-newsletter lease-label">FOR SUBLEASE</div>
+                {% endif %}
                 {% if page.sale %}
                 <div class="listing-label-newsletter rent-label">FOR SALE</div>
                 {% endif %}

--- a/_layouts/newsletter.html
+++ b/_layouts/newsletter.html
@@ -99,7 +99,14 @@
               <td width="50px"></td>
               <td width="400px" valign="top" class="bodyContent border-right">
                 <img class="amenities__icon" src="/images/newsletter/img/gs-newsletter-icon-3.png" width="45" height="45" alt="Rate" />
-                <span class="amenities__text"><span class="strong">Available:</span><span id="available-date" data-date="{{ page.date }}"> {{ page.date | date: "%m/%d/%Y" }}</span></span>
+                <span class="amenities__text">
+                  <div><span class="strong">Available:</span><span id="available-date" data-date="{{ page.date }}"> {{ page.date | date: "%m/%d/%Y" }}</div>
+                  <!-- dont try to display terms if it's just an empty string -->
+                  {% if page.terms == '' %}
+                  {% elsif page.terms %}
+                    <div><span class="strong">Terms:</span><span id="available-date" data-date="{{ page.date }}"> {{ page.terms}}</div>
+                  {% endif %}
+                </span>
               </td>
               <td width="400px" valign="top" class="bodyContent">
                 <img class="amenities__icon" src="/images/newsletter/img/gs-newsletter-icon-4.png" width="45" height="45" alt="Rate" />

--- a/_sass/listings.scss
+++ b/_sass/listings.scss
@@ -164,7 +164,7 @@
     width: 60%;
   }
 
-  .rent-label {
+  .sublease-label {
     background-color: #3678c6;
   }
 

--- a/_sass/newsletter.scss
+++ b/_sass/newsletter.scss
@@ -50,7 +50,7 @@
   vertical-align: middle;
   text-align: left;
   max-width: 265px;
-  color:#5e5e5e;
+  color: #5e5e5e;
   font-weight:700;
 }
 .newsletter-amenities2 {

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -308,15 +308,17 @@ function listingsSearch() {
 
 
   // var statusFilter = $('#status-filter').find(":selected").val().toLowerCase();
-  // var typeFilter = $('#type-filter').find(":selected").val().toLowerCase();
   // var minRoomFilter = parseInt($('#min-rooms').find(":selected").val());
+  var typeFilter = $('#type-filter').find(":selected").val().toLowerCase();
   var locationFilter = $('#location-filter').find(":selected").val().toLowerCase();
   var minSizeFilter = parseInt($('#min-size').val());
   var maxPriceFilter = parseInt($('#max-price').val());
 
   var filteredListings = $('.listing-preview').filter(function() {
     var lease = $(this).data("lease")
+    var sublease = $(this).data("sublease")
     return ($(this).data("location").toLowerCase() === locationFilter || locationFilter === "n/a") &&
+      ($(this).data("lease") === (typeFilter === "lease") || $(this).data("sublease") === (typeFilter === "sublease") || typeFilter === "n/a") &&
       (parseInt($(this).data("size").toString().replace(",", "")) >= minSizeFilter || isNaN(minSizeFilter)) &&
       (parseInt($(this).data("price").toString().replace(",", "")) <= maxPriceFilter || isNaN(maxPriceFilter))
   });


### PR DESCRIPTION
- Add 'Sublease' to type (For Sale, For Lease, For Sublease)
- If a listing's available date is in the past, have it print 'Immediately' if possible (will require some js logic) ... if not change this field to a string so that Chris's team can format the date however they like
- On the Newsletter, directly underneath 'Available' add a terms field... TODO: Ask Chris if he'd like to include terms anywhere else on the site
- On the listing, newsletter, and brochure, change "Property Highlights" to just "Highlights"